### PR TITLE
Include cstdint

### DIFF
--- a/src/FileReader.hpp
+++ b/src/FileReader.hpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <iomanip>
 


### PR DESCRIPTION
Fix compilation error with gcc (GCC) 11.2.0

```
src/FileReader.hpp:30:9: error: 'uint8_t' does not name a type
``` 